### PR TITLE
Update telegram link

### DIFF
--- a/static/mails/mailValidationToken.html
+++ b/static/mails/mailValidationToken.html
@@ -12,7 +12,7 @@
 <p style="white-space: pre-line">
 	Nous avons également ouvert un canal Telegram pour obtenir les dernières informations sur nos événement.
 	C'est un système à sens unique qui servira à vous tenir à jour des prochains événements pour ne rien
-	louper. <a href="https://t.me/+8y2MfAKrYrlmYzU0">https://t.me/+8y2MfAKrYrlmYzU0</a>
+	louper. <a href="https://t.me/+aJh4N0bJOSI1MDlk">https://t.me/+8y2MfAKrYrlmYzU0</a>
 </p>
 <h3>Membre</h3>
 <p style="white-space: pre-line">


### PR DESCRIPTION
The telegram link in the email is no longer valid.
Here's the new one.